### PR TITLE
Add basic profile APIs

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Profile;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Storage;
+
+class ProfileController extends Controller
+{
+    public function index()
+    {
+        return response()->json(Profile::all());
+    }
+
+    public function store(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'required|string',
+            'email' => 'required|email',
+            'mobile' => 'required|string',
+            'facebook' => 'nullable|string',
+            'insta_id' => 'nullable|string',
+            'telegram_id' => 'nullable|string',
+            'about_us' => 'nullable|string',
+            'city' => 'nullable|string',
+            'age' => 'nullable|integer',
+            'images.*' => 'image'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $data = $validator->validated();
+
+        if ($request->hasFile('images')) {
+            $paths = [];
+            foreach ($request->file('images') as $image) {
+                $paths[] = $image->store('profile_images', 'public');
+            }
+            $data['images'] = $paths;
+        }
+
+        $profile = Profile::create($data);
+
+        return response()->json($profile, 201);
+    }
+
+    public function update(Request $request, Profile $profile)
+    {
+        $validator = Validator::make($request->all(), [
+            'name' => 'sometimes|required|string',
+            'email' => 'sometimes|required|email',
+            'mobile' => 'sometimes|required|string',
+            'facebook' => 'nullable|string',
+            'insta_id' => 'nullable|string',
+            'telegram_id' => 'nullable|string',
+            'about_us' => 'nullable|string',
+            'city' => 'nullable|string',
+            'age' => 'nullable|integer',
+            'images.*' => 'image'
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $data = $validator->validated();
+
+        if ($request->hasFile('images')) {
+            $paths = [];
+            foreach ($request->file('images') as $image) {
+                $paths[] = $image->store('profile_images', 'public');
+            }
+            $data['images'] = $paths;
+        }
+
+        $profile->update($data);
+
+        return response()->json($profile);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -63,5 +63,6 @@ class Kernel extends HttpKernel
         'signed' => \App\Http\Middleware\ValidateSignature::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+        'jwt' => \App\Http\Middleware\VerifyJwt::class,
     ];
 }

--- a/app/Http/Middleware/VerifyJwt.php
+++ b/app/Http/Middleware/VerifyJwt.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Http\Request;
+
+class VerifyJwt
+{
+    private function base64UrlDecode(string $input): string
+    {
+        $remainder = strlen($input) % 4;
+        if ($remainder) {
+            $input .= str_repeat('=', 4 - $remainder);
+        }
+        return base64_decode(strtr($input, '-_', '+/')) ?: '';
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        $header = $request->header('Authorization');
+        if (!$header || !preg_match('/Bearer\s+(.*)/', $header, $matches)) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $token = $matches[1];
+        $parts = explode('.', $token);
+        if (count($parts) !== 3) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+        [$headerB64, $payloadB64, $signature] = $parts;
+
+        $expected = rtrim(strtr(base64_encode(hash_hmac('sha256', "$headerB64.$payloadB64", env('JWT_SECRET', 'secret'), true)), '+/', '-_'), '=');
+        if (!hash_equals($expected, $signature)) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+
+        $payload = json_decode($this->base64UrlDecode($payloadB64), true);
+        if (!$payload || !isset($payload['sub'])) {
+            return response()->json(['message' => 'Invalid token'], 401);
+        }
+
+        $user = User::find($payload['sub']);
+        if (!$user || !$user->is_admin) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+
+        return $next($request);
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Profile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'mobile',
+        'facebook',
+        'insta_id',
+        'telegram_id',
+        'about_us',
+        'city',
+        'age',
+        'images',
+    ];
+
+    protected $casts = [
+        'images' => 'array',
+    ];
+}

--- a/database/migrations/2024_01_02_000000_create_profiles_table.php
+++ b/database/migrations/2024_01_02_000000_create_profiles_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('profiles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('email');
+            $table->string('mobile');
+            $table->string('facebook')->nullable();
+            $table->string('insta_id')->nullable();
+            $table->string('telegram_id')->nullable();
+            $table->text('about_us')->nullable();
+            $table->string('city')->nullable();
+            $table->unsignedInteger('age')->nullable();
+            $table->json('images')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('profiles');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -19,5 +19,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 });
 
 use App\Http\Controllers\AdminAuthController;
+use App\Http\Controllers\ProfileController;
 
 Route::post('/admin/login', [AdminAuthController::class, 'login']);
+
+Route::get('/profiles', [ProfileController::class, 'index']);
+Route::middleware('jwt')->group(function () {
+    Route::post('/profiles', [ProfileController::class, 'store']);
+    Route::post('/profiles/{profile}', [ProfileController::class, 'update']);
+});


### PR DESCRIPTION
## Summary
- add a Profile model and migration
- implement ProfileController with list, create and update actions
- expose profile routes
- add JWT middleware for admin profile management

## Testing
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68540f018ba08330bac7209f473936ca