### PR TITLE
Add sorting, filtering and pagination to profiles API

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -9,10 +9,26 @@ use Illuminate\Support\Facades\Storage;
 
 class ProfileController extends Controller
 {
-    public function index()
+    public function index(Request $request)
     {
         try {
-            $profiles = Profile::all();
+            $query = Profile::query();
+
+            if ($city = $request->query('city')) {
+                $query->where('city', $city);
+            }
+
+            if ($request->boolean('is_random')) {
+                $query->inRandomOrder();
+            } else {
+                $sortBy = $request->query('sort_by', 'id');
+                $sortOrder = $request->query('sort_order', 'asc');
+                $query->orderBy($sortBy, $sortOrder);
+            }
+
+            $perPage = (int) $request->query('per_page', 15);
+            $profiles = $query->paginate($perPage);
+
             return response()->json([
                 'status' => true,
                 'data' => $profiles,
@@ -23,8 +39,6 @@ class ProfileController extends Controller
                 'message' => $e->getMessage(),
             ], 500);
         }
-        return response()->json(Profile::all());
-
     }
 
     public function store(Request $request)


### PR DESCRIPTION
## Summary
- support query parameters for filtering, sorting, pagination
- allow random ordering when `is_random=true`

## Testing
- `php artisan test`


------
https://chatgpt.com/codex/tasks/task_e_685415d5cd708330a897b01a2f3c1fe0