### PR TITLE
Add city migration, seeder and API

### DIFF
--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\City;
+
+class CityController extends Controller
+{
+    public function index()
+    {
+        try {
+            $cities = City::orderBy('name')->get();
+
+            return response()->json([
+                'status' => true,
+                'data' => $cities,
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class City extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+    ];
+}

--- a/database/migrations/2024_01_03_000000_create_cities_table.php
+++ b/database/migrations/2024_01_03_000000_create_cities_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cities', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cities');
+    }
+};

--- a/database/seeders/CitySeeder.php
+++ b/database/seeders/CitySeeder.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\City;
+use Illuminate\Database\Seeder;
+
+class CitySeeder extends Seeder
+{
+    public function run(): void
+    {
+        $cities = ['Delhi', 'Mumbai', 'Kolkata', 'Chennai', 'Bangalore'];
+
+        foreach ($cities as $name) {
+            City::firstOrCreate(['name' => $name]);
+        }
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
 use Database\Seeders\AdminSeeder;
+use Database\Seeders\CitySeeder;
 
 class DatabaseSeeder extends Seeder
 {
@@ -20,6 +21,9 @@ class DatabaseSeeder extends Seeder
         //     'email' => 'test@example.com',
         // ]);
 
-        $this->call(AdminSeeder::class);
+        $this->call([
+            AdminSeeder::class,
+            CitySeeder::class,
+        ]);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -20,10 +20,12 @@ Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
 
 use App\Http\Controllers\AdminAuthController;
 use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\CityController;
 
 Route::post('/admin/login', [AdminAuthController::class, 'login']);
 
 Route::get('/profiles', [ProfileController::class, 'index']);
+Route::get('/cities', [CityController::class, 'index']);
 Route::middleware('jwt')->group(function () {
     Route::post('/profiles', [ProfileController::class, 'store']);
     Route::post('/profiles/{profile}', [ProfileController::class, 'update']);


### PR DESCRIPTION
## Summary
- add migration for cities table
- add City model
- add CitySeeder and register it
- expose GET `/cities` API

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `php composer.phar install` *(fails: ext-dom and other extensions missing)*

------
https://chatgpt.com/codex/tasks/task_e_68543d0f76e08330bed2aed74ff61a3a