### PR TITLE
Add profile detail API

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -41,6 +41,21 @@ class ProfileController extends Controller
         }
     }
 
+    public function show(Profile $profile)
+    {
+        try {
+            return response()->json([
+                'status' => true,
+                'data' => $profile,
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
     public function store(Request $request)
     {
         try {

--- a/routes/api.php
+++ b/routes/api.php
@@ -25,6 +25,7 @@ use App\Http\Controllers\CityController;
 Route::post('/admin/login', [AdminAuthController::class, 'login']);
 
 Route::get('/profiles', [ProfileController::class, 'index']);
+Route::get('/profiles/{profile}', [ProfileController::class, 'show']);
 Route::get('/cities', [CityController::class, 'index']);
 Route::middleware('jwt')->group(function () {
     Route::post('/profiles', [ProfileController::class, 'store']);


### PR DESCRIPTION
## Summary
- implement `ProfileController@show` for single profile data
- expose the detail route via `GET /profiles/{profile}`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685507c661bc8330bf6d67314a41e9a1