### PR TITLE
Add unique validations for location entities

### DIFF
--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -33,7 +33,7 @@ class CityController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:cities,name',
                 'state_id' => 'required|exists:states,id',
                 'image' => 'nullable|image',
             ]);
@@ -69,7 +69,7 @@ class CityController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:cities,name,' . $city->id,
                 'state_id' => 'required|exists:states,id',
                 'image' => 'nullable|image',
             ]);

--- a/app/Http/Controllers/CountryController.php
+++ b/app/Http/Controllers/CountryController.php
@@ -28,7 +28,7 @@ class CountryController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:countries,name',
             ]);
 
             if ($validator->fails()) {
@@ -55,7 +55,7 @@ class CountryController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:countries,name,' . $country->id,
             ]);
 
             if ($validator->fails()) {

--- a/app/Http/Controllers/StateController.php
+++ b/app/Http/Controllers/StateController.php
@@ -32,7 +32,7 @@ class StateController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:states,name',
                 'country_id' => 'required|exists:countries,id',
             ]);
 
@@ -60,7 +60,7 @@ class StateController extends Controller
     {
         try {
             $validator = Validator::make($request->all(), [
-                'name' => 'required|string',
+                'name' => 'required|string|unique:states,name,' . $state->id,
                 'country_id' => 'required|exists:countries,id',
             ]);
 

--- a/database/migrations/2024_01_08_000000_add_unique_constraints_to_location_tables.php
+++ b/database/migrations/2024_01_08_000000_add_unique_constraints_to_location_tables.php
@@ -1,0 +1,33 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table->unique('name');
+        });
+        Schema::table('states', function (Blueprint $table) {
+            $table->unique('name');
+        });
+        Schema::table('cities', function (Blueprint $table) {
+            $table->unique('name');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('countries', function (Blueprint $table) {
+            $table->dropUnique('countries_name_unique');
+        });
+        Schema::table('states', function (Blueprint $table) {
+            $table->dropUnique('states_name_unique');
+        });
+        Schema::table('cities', function (Blueprint $table) {
+            $table->dropUnique('cities_name_unique');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- enforce uniqueness on country, state, and city names
- ensure controllers validate unique names
- add migration adding unique indexes

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_686201cd42dc83308739f7b29f46319e