### PR TITLE
Add location fields to profiles

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -18,6 +18,18 @@ class ProfileController extends Controller
                 $query->where('city', $city);
             }
 
+            if ($cityId = $request->query('city_id')) {
+                $query->where('city_id', $cityId);
+            }
+
+            if ($stateId = $request->query('state_id')) {
+                $query->where('state_id', $stateId);
+            }
+
+            if ($countryId = $request->query('country_id')) {
+                $query->where('country_id', $countryId);
+            }
+
             if ($request->boolean('is_random')) {
                 $query->inRandomOrder();
             } else {
@@ -72,6 +84,9 @@ class ProfileController extends Controller
                 'video_call_link' => 'nullable|string',
                 'about_us' => 'nullable|string',
                 'city' => 'nullable|string',
+                'city_id' => 'nullable|exists:cities,id',
+                'state_id' => 'nullable|exists:states,id',
+                'country_id' => 'nullable|exists:countries,id',
                 'age' => 'nullable|integer',
                 'images.*' => 'image'
             ]);
@@ -127,6 +142,9 @@ class ProfileController extends Controller
                 'video_call_link' => 'nullable|string',
                 'about_us' => 'nullable|string',
                 'city' => 'nullable|string',
+                'city_id' => 'nullable|exists:cities,id',
+                'state_id' => 'nullable|exists:states,id',
+                'country_id' => 'nullable|exists:countries,id',
                 'age' => 'nullable|integer',
                 'images.*' => 'image'
             ]);

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -21,6 +21,9 @@ class Profile extends Model
         'video_call_link',
         'about_us',
         'city',
+        'city_id',
+        'state_id',
+        'country_id',
         'age',
         'images',
     ];

--- a/database/migrations/2024_01_09_000000_add_location_to_profiles_table.php
+++ b/database/migrations/2024_01_09_000000_add_location_to_profiles_table.php
@@ -1,0 +1,25 @@
+<?php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->foreignId('country_id')->nullable()->after('city')->constrained()->cascadeOnDelete();
+            $table->foreignId('state_id')->nullable()->after('country_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('city_id')->nullable()->after('state_id')->constrained()->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('profiles', function (Blueprint $table) {
+            $table->dropConstrainedForeignId('city_id');
+            $table->dropConstrainedForeignId('state_id');
+            $table->dropConstrainedForeignId('country_id');
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- support optional `city_id`, `state_id`, and `country_id` when creating or updating profiles
- allow filtering profiles by location IDs
- store new location relations in the model
- add migration for the new foreign keys

## Testing
- `./vendor/bin/phpunit --version` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6863580eaae88330b09105565b13ebd1