### PR TITLE
Add endpoint returning all cities

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,10 @@ php artisan db:seed --class=AdminSeeder
 
 Then send a `POST /api/admin/login` request with `email` and `password` to obtain a JWT token along with the admin's name and email.
 
+## API Endpoints
+
+- `GET /api/cities` - Retrieve a list of all cities.
+
 ## License
 
 The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).

--- a/app/Http/Controllers/CityController.php
+++ b/app/Http/Controllers/CityController.php
@@ -31,6 +31,28 @@ class CityController extends Controller
         }
     }
 
+    /**
+     * Return all cities regardless of state.
+     */
+    public function all()
+    {
+        try {
+            $cities = City::query()
+                ->orderBy('name')
+                ->get();
+
+            return response()->json([
+                'status' => true,
+                'data' => $cities,
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
     public function store(Request $request)
     {
         try {

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::post('/admin/login', [AdminAuthController::class, 'login']);
 
 Route::get('/profiles', [ProfileController::class, 'index']);
 Route::get('/profiles/{profile}', [ProfileController::class, 'show']);
+Route::get('/cities', [CityController::class, 'all']);
 Route::get('/cities/{id}', [CityController::class, 'index']);
 Route::get('/countries', [CountryController::class, 'index']);
 Route::get('/states/{id}', [StateController::class, 'index']);


### PR DESCRIPTION
## Summary
- add `all` method to `CityController`
- expose new `GET /api/cities` route
- document endpoint in README

## Testing
- `php artisan test` *(fails: missing vendor autoload)*

------
https://chatgpt.com/codex/tasks/task_e_6864d4c85a9083309d6caba99e0da029