### PR TITLE
Enhance profile API with city and country data

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -12,7 +12,7 @@ class ProfileController extends Controller
     public function index(Request $request)
     {
         try {
-            $query = Profile::query();
+            $query = Profile::with(['cityRelation', 'state', 'country']);
 
             if ($city = $request->query('city')) {
                 $query->where('city', $city);
@@ -56,6 +56,7 @@ class ProfileController extends Controller
     public function show(Profile $profile)
     {
         try {
+            $profile->load(['cityRelation', 'state', 'country']);
             return response()->json([
                 'status' => true,
                 'data' => $profile,

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -4,6 +4,9 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use App\Models\City;
+use App\Models\State;
+use App\Models\Country;
 
 class Profile extends Model
 {
@@ -31,4 +34,19 @@ class Profile extends Model
     protected $casts = [
         'images' => 'array',
     ];
+
+    public function cityRelation()
+    {
+        return $this->belongsTo(City::class, 'city_id');
+    }
+
+    public function state()
+    {
+        return $this->belongsTo(State::class);
+    }
+
+    public function country()
+    {
+        return $this->belongsTo(Country::class);
+    }
 }


### PR DESCRIPTION
## Summary
- expose related city, state, and country data when listing or showing profiles
- add relationship methods on `Profile` model

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864db0ad10883309c77a87b4bdeba26