### PR TITLE
Add API endpoint for recording profile views

### DIFF
--- a/app/Http/Controllers/ProfileController.php
+++ b/app/Http/Controllers/ProfileController.php
@@ -78,6 +78,28 @@ class ProfileController extends Controller
         }
     }
 
+    public function storeView(Request $request, Profile $profile)
+    {
+        try {
+            ProfileView::firstOrCreate([
+                'profile_id' => $profile->id,
+                'ip_address' => $request->ip(),
+            ]);
+
+            $profile->loadCount('views');
+
+            return response()->json([
+                'status' => true,
+                'data' => ['views_count' => $profile->views_count],
+            ]);
+        } catch (\Exception $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
     public function store(Request $request)
     {
         try {

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,7 @@ Route::post('/admin/login', [AdminAuthController::class, 'login']);
 
 Route::get('/profiles', [ProfileController::class, 'index']);
 Route::get('/profiles/{profile}', [ProfileController::class, 'show']);
+Route::post('/profiles/{profile}/views', [ProfileController::class, 'storeView']);
 Route::get('/cities', [CityController::class, 'all']);
 Route::get('/cities/{id}', [CityController::class, 'index']);
 Route::get('/countries', [CountryController::class, 'index']);

--- a/tests/Feature/ProfileViewTest.php
+++ b/tests/Feature/ProfileViewTest.php
@@ -33,4 +33,24 @@ class ProfileViewTest extends TestCase
             ->assertStatus(200)
             ->assertJsonPath('data.data.0.views_count', 2);
     }
+
+    public function test_store_profile_view_via_endpoint(): void
+    {
+        $profile = Profile::factory()->create();
+
+        $this->postJson('/api/profiles/'.$profile->id.'/views', [], ['REMOTE_ADDR' => '1.1.1.1'])
+            ->assertStatus(200)
+            ->assertJson(['status' => true])
+            ->assertJsonPath('data.views_count', 1);
+
+        // same IP should not increase count
+        $this->postJson('/api/profiles/'.$profile->id.'/views', [], ['REMOTE_ADDR' => '1.1.1.1'])
+            ->assertStatus(200)
+            ->assertJsonPath('data.views_count', 1);
+
+        // different IP should increase count
+        $this->postJson('/api/profiles/'.$profile->id.'/views', [], ['REMOTE_ADDR' => '2.2.2.2'])
+            ->assertStatus(200)
+            ->assertJsonPath('data.views_count', 2);
+    }
 }


### PR DESCRIPTION
## Summary
- allow recording profile views separately
- add `/profiles/{profile}/views` POST route
- implement `storeView` controller method
- test profile view creation via new endpoint

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68679e614dd48330bdd1db7406b3b564