### PR TITLE
Implement google analytics code API

### DIFF
--- a/app/Http/Controllers/GoogleAnalyticController.php
+++ b/app/Http/Controllers/GoogleAnalyticController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\GoogleAnalytic;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+
+class GoogleAnalyticController extends Controller
+{
+    public function index()
+    {
+        try {
+            $code = GoogleAnalytic::first();
+            return response()->json([
+                'status' => true,
+                'data' => $code,
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function store(Request $request)
+    {
+        try {
+            $validator = Validator::make($request->all(), [
+                'code' => 'required|string',
+            ]);
+
+            if ($validator->fails()) {
+                return response()->json([
+                    'status' => false,
+                    'errors' => $validator->errors(),
+                ], 422);
+            }
+
+            $data = $validator->validated();
+            $code = GoogleAnalytic::updateOrCreate(['id' => 1], $data);
+
+            return response()->json([
+                'status' => true,
+                'data' => $code,
+            ], 201);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'status' => false,
+                'message' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/app/Models/GoogleAnalytic.php
+++ b/app/Models/GoogleAnalytic.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class GoogleAnalytic extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'code',
+    ];
+}

--- a/database/factories/GoogleAnalyticFactory.php
+++ b/database/factories/GoogleAnalyticFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\GoogleAnalytic;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class GoogleAnalyticFactory extends Factory
+{
+    protected $model = GoogleAnalytic::class;
+
+    public function definition(): array
+    {
+        return [
+            'code' => '<script>console.log("ga")</script>',
+        ];
+    }
+}
+

--- a/database/migrations/2024_01_12_000000_create_google_analytics_table.php
+++ b/database/migrations/2024_01_12_000000_create_google_analytics_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('google_analytics', function (Blueprint $table) {
+            $table->id();
+            $table->text('code');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('google_analytics');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,6 +24,7 @@ use App\Http\Controllers\CityController;
 use App\Http\Controllers\CountryController;
 use App\Http\Controllers\StateController;
 use App\Http\Controllers\PageScriptController;
+use App\Http\Controllers\GoogleAnalyticController;
 
 Route::post('/admin/login', [AdminAuthController::class, 'login']);
 
@@ -37,6 +38,8 @@ Route::get('/states/{id}', [StateController::class, 'index']);
 Route::get('/page-scripts', [PageScriptController::class, 'index']);
 Route::post('/page-scripts', [PageScriptController::class, 'store']);
 Route::post('/page-scripts/{pageScript}', [PageScriptController::class, 'update']);
+Route::get('/google-analytics', [GoogleAnalyticController::class, 'index']);
+Route::post('/google-analytics', [GoogleAnalyticController::class, 'store']);
 Route::middleware('jwt')->group(function () {
     Route::post('/profiles', [ProfileController::class, 'store']);
     Route::post('/profiles/{profile}', [ProfileController::class, 'update']);

--- a/tests/Feature/GoogleAnalyticTest.php
+++ b/tests/Feature/GoogleAnalyticTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\GoogleAnalytic;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class GoogleAnalyticTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_store_google_analytic_code(): void
+    {
+        $payload = ['code' => '<script>ga</script>'];
+
+        $this->postJson('/api/google-analytics', $payload)
+            ->assertStatus(201)
+            ->assertJson(['status' => true])
+            ->assertJsonPath('data.code', '<script>ga</script>');
+    }
+
+    public function test_get_google_analytic_code(): void
+    {
+        GoogleAnalytic::factory()->create(['code' => 'x']);
+
+        $this->getJson('/api/google-analytics')
+            ->assertStatus(200)
+            ->assertJsonPath('data.code', 'x');
+    }
+}
+


### PR DESCRIPTION
## Summary
- add GoogleAnalytic model and controller
- support CRUD endpoints for analytics code
- create migration for `google_analytics` table
- add factory and tests for analytics endpoint

## Testing
- `phpunit` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686e4359093883309ec27512b366e27d